### PR TITLE
HSDO-527: Change the search and replace to file styles only

### DIFF
--- a/stanford_s3fs_if.module
+++ b/stanford_s3fs_if.module
@@ -18,6 +18,14 @@ function stanford_s3fs_if_filter_info() {
   return $filters;
 }
 
+/**
+ * Replace image derivative code with local paths.
+ *
+ * @param $text
+ * @param $filter
+ * @param $format
+ * @return mixed
+ */
 function _stanford_s3fs_if_s3fs_generate_derivatives_process($text, $filter, $format) {
   $bucket = variable_get('s3fs_bucket');
   $region = variable_get('s3fs_region');
@@ -25,9 +33,9 @@ function _stanford_s3fs_if_s3fs_generate_derivatives_process($text, $filter, $fo
   if (variable_get('s3fs_use_https') === 1) {
     $s = 's';
   }
-//  $search = 'https://files-sws-build-drupal-anchorage-stanford-edu.s3-us-west-2.amazonaws.com/s3fs-public/';
-  $search = 'http' . $s . "://" . $bucket . ".s3-" . $region . ".amazonaws.com/s3fs-public/styles";
-  $replace = '/s3/files/styles';
+//  $search = 'https://files-sws-build-drupal-anchorage-stanford-edu.s3-us-west-2.amazonaws.com/s3fs-public/styles/';
+  $search = 'http' . $s . "://" . $bucket . ".s3-" . $region . ".amazonaws.com/s3fs-public/styles/";
+  $replace = '/s3/files/styles/';
 //  Uncomment lines below to re-enable logging.
 //  watchdog('stanford_s3fs_if',"Search string is: @search", array('@search' => $search));
 //  watchdog('stanford_s3fs_if',"Replace string is: @replace", array('@replace' => $replace));


### PR DESCRIPTION
Adding /styles/ to the search and replace token in order to avoid re-writing paths to the image source or non-image files.
